### PR TITLE
Style: reset.css & 색상 변수 & 기타 CSS 맞춤 설정 #9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-router-dom": "^6.10.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.9",
+        "styled-reset": "^4.4.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -15127,6 +15128,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/styled-reset": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.5.tgz",
+      "integrity": "sha512-uEQzbCqSBbx1ZT9VuquoGOJyVzs3kMIMCyjxmtSo4/JoTCrq92UFTJx91KcdMncDaymz6NE8sgSvstHHcJjExg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">=4.0.0 || >=5.0.0"
+      }
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -27798,6 +27810,12 @@
           }
         }
       }
+    },
+    "styled-reset": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.4.5.tgz",
+      "integrity": "sha512-uEQzbCqSBbx1ZT9VuquoGOJyVzs3kMIMCyjxmtSo4/JoTCrq92UFTJx91KcdMncDaymz6NE8sgSvstHHcJjExg==",
+      "requires": {}
     },
     "stylehacks": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-router-dom": "^6.10.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.9",
+    "styled-reset": "^4.4.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,10 @@
+import { GlobalStyle } from "./app.style";
 import Router from "./routes/Router";
 
 function App() {
     return (
         <>
+            <GlobalStyle />
             <Router />
         </>
     );

--- a/src/app.style.js
+++ b/src/app.style.js
@@ -1,0 +1,49 @@
+import { createGlobalStyle } from "styled-components";
+import reset from "styled-reset";
+
+export const GlobalStyle = createGlobalStyle`
+    ${reset}
+
+    :root {
+        --color-main-solid: #5B4A92;
+        --color-main-mild: #E1CAEF;
+        --color-main-mild-side: #E1DDF4;
+        --color-solid-gray: #767676;
+        --color-mild-gray: #DBDBDB;
+        --color-text-main: #000000;
+        --color-text-warn: #E41B3F;
+    }
+
+    * {
+        box-sizing: border-box;
+        color: var(--color-text-main);
+    }
+
+    html {
+        font-size: 62.5%;
+    }
+
+    button {
+        border: none;
+        cursor: pointer;
+        :disabled {
+            cursor: not-allowed;
+        }
+    }
+
+    a {
+        text-decoration: none;
+    }
+
+    .hidden {
+        display: none;
+    }
+
+    .ir {
+        position: absolute;
+        clip-path: inset(50%);
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+    }
+`;


### PR DESCRIPTION
* reset.css: styled-reset 이용
* 색상 변수
* 기타 CSS 맞춤 설정
    * html 폰트 사이즈를 62.5%로
    * box-sizing: border-box
    * .hidden: display: none
    * .ir: 스크린 리더 사용자 위함
    * 버튼: 커서, border none
    * a 태그: text-decoration: none