### PR TITLE
Feat: 회원 가입 페이지 #15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.3.5",
         "eslint-plugin-jsx-a11y": "^6.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4866,6 +4867,29 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -13657,6 +13681,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -20373,6 +20402,28 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
     },
+    "axios": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+      "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -26733,6 +26784,11 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.3.5",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/common/FormCont/FormCont.jsx
+++ b/src/components/common/FormCont/FormCont.jsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+const FormCont = styled.form`
+    padding: 0 34px;
+    & > div:last-of-type {
+        margin-top: 20px;
+    }
+    & button {
+        margin-top: 40px;
+    }
+`;
+
+export default FormCont;

--- a/src/components/common/LabelOnTop/labelOnTop.style.js
+++ b/src/components/common/LabelOnTop/labelOnTop.style.js
@@ -1,6 +1,10 @@
 import styled from "styled-components";
 
 const LabelOnTopWrapper = styled.h1`
+    margin: 55px 0 42px;
+    text-align: center;
+    font-size: 2.4rem;
+    font-weight: 500;
 `;
 
 export default LabelOnTopWrapper;

--- a/src/components/common/WarnMsg/WarnMsg.jsx
+++ b/src/components/common/WarnMsg/WarnMsg.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import WarnMsgWrapper from "./warnMsg.style";
+
+const WarnMsg = React.forwardRef((props, ref) => {
+    return <WarnMsgWrapper className={props.className} ref={ref}>{props.children}</WarnMsgWrapper>
+});
+
+export default WarnMsg;

--- a/src/components/common/WarnMsg/warnMsg.style.js
+++ b/src/components/common/WarnMsg/warnMsg.style.js
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 
-const WarnMsg = styled.p`
+const WarnMsgWrapper = styled.p`
     margin-top: 4px;
     font-size: 1.2rem;
     color: var(--color-text-warn);
 `;
 
-export default WarnMsg;
+export default WarnMsgWrapper;

--- a/src/components/signup/SignUpForm/SignUpForm.jsx
+++ b/src/components/signup/SignUpForm/SignUpForm.jsx
@@ -2,19 +2,49 @@ import FormCont from "../../common/FormCont/FormCont";
 import UserInput from "../../common/UserInput/UserInput";
 import WarnMsg from "../../common/WarnMsg/warnMsg";
 import Button from "../../common/Button/Button";
+import useValidityCheck from "../../../hooks/useValidityCheck";
 
 export default function SignUpForm() {
+    const {
+        emailValue,
+        emailIsValid,
+        pwValue,
+        pwIsValid,
+        isFormValid,
+        emailChangeHandler,
+        pwChangeHandler,
+    } = useValidityCheck();
     return (
         <FormCont>
             <UserInput label="이메일" inputId="email">
-                <input id="email" type="email" data-testid="email-input" placeholder="이메일 주소를 입력해 주세요." />
-                <WarnMsg>동일한 이메일이 이미 존재합니다.</WarnMsg>
+                <input
+                    id="email"
+                    type="email"
+                    value={emailValue}
+                    onChange={emailChangeHandler}
+                    data-testid="email-input"
+                    placeholder="이메일 주소를 입력해 주세요."
+                />
+                <WarnMsg className={emailIsValid === false ? "" : "hidden"}>이메일은 "@"을 포함해야 합니다.</WarnMsg>
             </UserInput>
             <UserInput label="비밀번호" inputId="pw">
-                <input id="pw" type="password" data-testid="password-input" placeholder="8자 이상의 비밀번호를 입력해 주세요." />
-                <WarnMsg>비밀번호는 8자 이상이어야 합니다.</WarnMsg>
+                <input
+                    id="pw"
+                    type="password"
+                    value={pwValue}
+                    onChange={pwChangeHandler}
+                    data-testid="password-input"
+                    placeholder="8자 이상의 비밀번호를 입력해 주세요."
+                />
+                <WarnMsg className={pwIsValid === false ? "" : "hidden"}>비밀번호는 8자 이상이어야 합니다.</WarnMsg>
             </UserInput>
-            <Button className="form-item" data-testid="signup-button" disabled>회원가입</Button>
+            <Button
+                className="form-item"
+                data-testid="signup-button"
+                disabled={!isFormValid}
+            >
+                회원가입
+            </Button>
         </FormCont>
     );
 }

--- a/src/components/signup/SignUpForm/SignUpForm.jsx
+++ b/src/components/signup/SignUpForm/SignUpForm.jsx
@@ -1,0 +1,20 @@
+import FormCont from "../../common/FormCont/FormCont";
+import UserInput from "../../common/UserInput/UserInput";
+import WarnMsg from "../../common/WarnMsg/warnMsg";
+import Button from "../../common/Button/Button";
+
+export default function SignUpForm() {
+    return (
+        <FormCont>
+            <UserInput label="이메일" inputId="email">
+                <input id="email" type="email" data-testid="email-input" placeholder="이메일 주소를 입력해 주세요." />
+                <WarnMsg>동일한 이메일이 이미 존재합니다.</WarnMsg>
+            </UserInput>
+            <UserInput label="비밀번호" inputId="pw">
+                <input id="pw" type="password" data-testid="password-input" placeholder="8자 이상의 비밀번호를 입력해 주세요." />
+                <WarnMsg>비밀번호는 8자 이상이어야 합니다.</WarnMsg>
+            </UserInput>
+            <Button className="form-item" data-testid="signup-button" disabled>회원가입</Button>
+        </FormCont>
+    );
+}

--- a/src/components/signup/SignUpForm/SignUpForm.jsx
+++ b/src/components/signup/SignUpForm/SignUpForm.jsx
@@ -1,6 +1,6 @@
 import FormCont from "../../common/FormCont/FormCont";
 import UserInput from "../../common/UserInput/UserInput";
-import WarnMsg from "../../common/WarnMsg/warnMsg";
+import WarnMsg from "../../common/WarnMsg/WarnMsg";
 import Button from "../../common/Button/Button";
 import useValidityCheck from "../../../hooks/useValidityCheck";
 
@@ -8,14 +8,16 @@ export default function SignUpForm() {
     const {
         emailValue,
         emailIsValid,
+        warnEmailRef,
         pwValue,
         pwIsValid,
         isFormValid,
         emailChangeHandler,
         pwChangeHandler,
+        submitHandler
     } = useValidityCheck();
     return (
-        <FormCont>
+        <FormCont onSubmit={(e) => submitHandler(e, "signup")}>
             <UserInput label="이메일" inputId="email">
                 <input
                     id="email"
@@ -25,7 +27,7 @@ export default function SignUpForm() {
                     data-testid="email-input"
                     placeholder="이메일 주소를 입력해 주세요."
                 />
-                <WarnMsg className={emailIsValid === false ? "" : "hidden"}>이메일은 "@"을 포함해야 합니다.</WarnMsg>
+                <WarnMsg className={emailIsValid === false ? "" : "hidden"} ref={warnEmailRef}>이메일은 "@"을 포함해야 합니다.</WarnMsg>
             </UserInput>
             <UserInput label="비밀번호" inputId="pw">
                 <input
@@ -40,6 +42,7 @@ export default function SignUpForm() {
             </UserInput>
             <Button
                 className="form-item"
+                type="submit"
                 data-testid="signup-button"
                 disabled={!isFormValid}
             >

--- a/src/hooks/use-http.jsx
+++ b/src/hooks/use-http.jsx
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import axios from "axios";
+
+const useHttp = () => {
+    const sendRequest = useCallback(async (requestConfig, applyData, errorHandler) => {
+        try {
+            const response = await axios({
+                method: requestConfig.method ? requestConfig.method : "GET",
+                url: `https://www.pre-onboarding-selection-task.shop${requestConfig.URL}`,
+                data: requestConfig.data ? requestConfig.data : {},
+                headers: requestConfig.headers ? requestConfig.headers : {}
+            });
+
+            console.log(response.status);
+
+            console.log(applyData);
+            applyData(response.data);
+        } catch (err) {
+            errorHandler(err);
+        }
+    }, []);
+
+    return sendRequest;
+};
+
+export default useHttp;

--- a/src/hooks/use-http.jsx
+++ b/src/hooks/use-http.jsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import axios from "axios";
 
 const useHttp = () => {
-    const sendRequest = useCallback(async (requestConfig, applyData, errorHandler) => {
+    const sendRequest = useCallback(async (requestConfig, responseHandler, errorHandler) => {
         try {
             const response = await axios({
                 method: requestConfig.method ? requestConfig.method : "GET",
@@ -11,10 +11,7 @@ const useHttp = () => {
                 headers: requestConfig.headers ? requestConfig.headers : {}
             });
 
-            console.log(response.status);
-
-            console.log(applyData);
-            applyData(response.data);
+            responseHandler(response);
         } catch (err) {
             errorHandler(err);
         }

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -2,10 +2,9 @@ import { useState, useEffect, useReducer, useCallback, useRef } from "react";
 import useHttp from "./use-http";
 
 const emailReducer = (state, action) => {
-    if (action.type === "notUnique") {
-        return { value: state.value, isValid: false };
-    }
-    return { value: action.val, isValid: action.val.includes("@") };
+    return action.type === "notUnique" ? 
+        { value: state.value, isValid: false } : 
+        { value: action.val, isValid: action.val.includes("@") };
 };
 
 const passwordReducer = (state, action) => {
@@ -81,7 +80,6 @@ export default function useValidityCheck() {
                 const errMsg = err.response.data.message;
                 warnEmailRef.current.textContent = errMsg;
                 dispatchEmail({ type: "notUnique" });
-                setIsFormValid(false);
             };
         }
 

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -1,6 +1,10 @@
-import { useState, useEffect, useReducer, useCallback} from "react";
+import { useState, useEffect, useReducer, useCallback, useRef } from "react";
+import useHttp from "./use-http";
 
 const emailReducer = (state, action) => {
+    if (action.type === "notUnique") {
+        return { value: state.value, isValid: false };
+    }
     return { value: action.val, isValid: action.val.includes("@") };
 };
 
@@ -24,11 +28,13 @@ export default function useValidityCheck() {
     const { value: emailValue, isValid: emailIsValid } = emailState;
     const { value: pwValue, isValid: pwIsValid } = pwState;
 
+    const warnEmailRef = useRef();
+
+    const sendRequest = useHttp();
+
     useEffect(() => {
         const identifier = setTimeout(() => {
-            setIsFormValid(
-                emailIsValid && pwIsValid
-            );
+            setIsFormValid(emailIsValid && pwIsValid);
         }, 300);
 
         return () => {
@@ -37,6 +43,10 @@ export default function useValidityCheck() {
     }, [emailIsValid, pwIsValid]);
 
     const emailChangeHandler = useCallback((e) => {
+        if (warnEmailRef.current.textContent !== '이메일은 "@"을 포함해야 합니다.') {
+            console.log("경고 메시지 다시 초기값으로");
+            warnEmailRef.current.textContent = '이메일은 "@"을 포함해야 합니다.';
+        }
         dispatchEmail({ val: e.target.value });
     }, []);
 
@@ -44,13 +54,49 @@ export default function useValidityCheck() {
         dispatchPw({ val: e.target.value });
     }, []);
 
+    const submitHandler = useCallback((e, type) => {
+        e.preventDefault();
+        const reqConfig = {
+            method: "POST",
+            URL: type === "signup" ? "/auth/signup" : "/auth/signin",
+            data: {
+                email: emailValue,
+                password: pwValue
+            },
+            headers: {
+                "Content-Type": "application/json"
+            }
+        };
+
+        let applyDataHandler;
+        if (type === "signup") {
+            applyDataHandler = (data) => {
+                console.log(data);
+            };
+        }
+
+        let errorHandler;
+        if (type === "signup") {
+            errorHandler = (err) => {
+                const errMsg = err.response.data.message;
+                warnEmailRef.current.textContent = errMsg;
+                dispatchEmail({ type: "notUnique" });
+                setIsFormValid(false);
+            };
+        }
+
+        sendRequest(reqConfig, applyDataHandler, errorHandler);
+    }, [emailValue, pwValue, sendRequest]);
+
     return {
         emailValue,
         emailIsValid,
+        warnEmailRef,
         pwValue,
         pwIsValid,
         isFormValid,
         emailChangeHandler,
-        pwChangeHandler
+        pwChangeHandler,
+        submitHandler
     };
 }

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useReducer, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import useHttp from "./use-http";
 
 const emailReducer = (state, action) => {
@@ -30,6 +31,7 @@ export default function useValidityCheck() {
     const warnEmailRef = useRef();
 
     const sendRequest = useHttp();
+    const navigate = useNavigate();
 
     useEffect(() => {
         const identifier = setTimeout(() => {
@@ -67,10 +69,10 @@ export default function useValidityCheck() {
             }
         };
 
-        let applyDataHandler;
+        let responseHandler;
         if (type === "signup") {
-            applyDataHandler = (data) => {
-                console.log(data);
+            responseHandler = (res) => {
+                res.status === 201 && navigate("/signin");
             };
         }
 
@@ -83,8 +85,8 @@ export default function useValidityCheck() {
             };
         }
 
-        sendRequest(reqConfig, applyDataHandler, errorHandler);
-    }, [emailValue, pwValue, sendRequest]);
+        sendRequest(reqConfig, responseHandler, errorHandler);
+    }, [emailValue, pwValue, sendRequest, navigate]);
 
     return {
         emailValue,

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -1,0 +1,56 @@
+import { useState, useEffect, useReducer, useCallback} from "react";
+
+const emailReducer = (state, action) => {
+    return { value: action.val, isValid: action.val.includes("@") };
+};
+
+const passwordReducer = (state, action) => {
+    return { value: action.val, isValid: action.val.length >= 8 };
+};
+
+export default function useValidityCheck() {
+    const [emailState, dispatchEmail] = useReducer(emailReducer, {
+        value: "",
+        isValid: null,
+    });
+
+    const [pwState, dispatchPw] = useReducer(passwordReducer, {
+        value: "",
+        isValid: null,
+    });
+
+    const [isFormValid, setIsFormValid] = useState(false);
+
+    const { value: emailValue, isValid: emailIsValid } = emailState;
+    const { value: pwValue, isValid: pwIsValid } = pwState;
+
+    useEffect(() => {
+        const identifier = setTimeout(() => {
+            setIsFormValid(
+                emailIsValid && pwIsValid
+            );
+        }, 300);
+
+        return () => {
+            clearTimeout(identifier);
+        };
+    }, [emailIsValid, pwIsValid]);
+
+    const emailChangeHandler = useCallback((e) => {
+        dispatchEmail({ val: e.target.value });
+    }, []);
+
+    const pwChangeHandler = useCallback((e) => {
+        dispatchPw({ val: e.target.value });
+    }, []);
+
+    return {
+        emailValue,
+        emailIsValid,
+        pwValue,
+        pwIsValid,
+        isFormValid,
+        emailChangeHandler,
+        pwChangeHandler
+    };
+}

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,5 +1,11 @@
-import React from "react";
+import LabelOnTop from "../components/common/LabelOnTop/LabelOnTop";
+import SignUpForm from "../components/signup/SignUpForm/SignUpForm";
 
 export default function SignUp() {
-    return <div>SignUp</div>;
+    return (
+        <>
+            <LabelOnTop>회원가입</LabelOnTop>
+            <SignUpForm />
+        </>
+    );
 }


### PR DESCRIPTION
# [Markup & Style: 컴포넌트 조합 통해 회원가입 페이지 기본 마크업 구성 및 스타일링](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/16/commits/86f03142c16949caaa0be60b40ed75a02bed0999)
## component/common/FormCont
로그인 페이지와 회원가입 페이지 모두 폼의 스타일이 동일, FormCont는 CSS 중복 방지 위한 form styled component임
## component/signup/SignUpForm.jsx
위에서 만들어 둔 FormCont를 이용해, 회원가입 폼 컴포넌트 만듦
# [Feat: 디바운싱 이용해 이메일, 비밀번호 유효 여부 검증](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/16/commits/7a1bf0e74e42602d428dcf1b7a58c7020dbf522c)
## useValidityCheck.jsx
* 로그인, 회원가입 모두 디바운싱 이용해 유효성 여부를 검증할 것임.
* 둘 다 로직이 똑같아서 src/hooks 하에 넣음 (공통 hooks)
* useReducer를 이용해 input의 값과, 해당 input의 validity 여부를 한 번에 관리
* useCallback을 이용해 emailChangeHandler와 pwChangeHandler 재생성 방지

## SignUpForm.jsx
useValidityCheck.jsx를 이용해 유효 여부에 따라 렌더링 달리함
# [Chore: axios 다운로드](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/16/commits/408acf348df804e4da155f3bef0b4dd913c71b59)
# [Feat: 회원 가입 요청 (요청 성공 후 로직은 아직 미완성)](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/16/commits/f151d803e6ee1f10d9af7a16d114c6d1494b93c3)
## use-http.jsx
* 파라미터
    * requestConfig: HTTP 요청 세부 사항
    * applyData: 요청 성공시 호출
    * errorHandler: 요청 실패시 호출

## WarnMsg.jsx
* forwardRef 이용: 회원가입 요청 후 이메일 중복이면 그에 따라 경고 메시지 바꾸기 위함

## useValidityCheck.jsx
* 추가 사항
    * useHttp 이용한 회원가입 요청 로직
    * 제출 후 요청 실패시, 이메일 하단 경고 메시지를 바꾸고 버튼 비활성화 하는 로직
    * 폼 제출시 실행되는 함수를 조건문을 이용해, 회원가입 페이지뿐만 아니라 추후 로그인 페이지에서도 활용할 수 있게 함

## 한계점
### useValidityCheck.jsx
* 83번 라인에서, 만약 회원가입 요청 오류 원인이 아이디 중복이 아니라면 타입 키에 대한 값으로 notUnique는 부적절함
* 46 ~ 49 라인, WarnMsg를 useRef로 처리하다 보니 일단 이렇게 짜놓음. 더 최선은 없는지 알아봐야겠다.

# [Refactor: useValidityCheck.jsx](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/16/commits/b0a28ce89c0be0cd7df70cf499bbe159a7f3ab57)
* submitHandler 내 회원가입 errorHandler
    * 수정 전: dispatchEmail 호출 후 setIsFormValid로 isFormValid 업데이트 또 함
    * 문제: dispatchEmail을 호출하면 emailIsValid가 바뀜 -> emilaIsValid 또는 pwIsValid에 의존하는 useEffect가 실행되며 isFormValid를 업데이트 -> 그러면 굳이 수정 전처럼 dispatchEmail 호출 후 isFormValid 업데이트 할 필요 없음
    * 해결: setIsFormValid로 isFormValid 업데이트하는 코드 삭제
* emailReducer return을 삼항 연산자로

# [Feat: 회원가입 요청 성공시 로그인 페이지로 이동](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/16/commits/97c309c70f4d3a462feb03e53d7e1076d907b334)
## useValidityCheck.jsx
* useNavigate를 이용해 회원가입 요청 응답 상태가 201이면 로그인 페이지로 이동

## use-http.jsx
* 기존: applyData(response.data)
* 수정: responseHandler(response)
    * 응답의 data뿐만 아니라 status도 사용하고 싶어서 보다 포괄적인 이름으로 변경