### PR TITLE
Feat: 로그인 페이지 #17

### DIFF
--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -9,6 +9,7 @@ export default function Form({ type }) {
         emailValue,
         emailIsValid,
         warnEmailRef,
+        warnPwRef,
         pwValue,
         pwIsValid,
         isFormValid,
@@ -43,7 +44,10 @@ export default function Form({ type }) {
                     data-testid="password-input"
                     placeholder="8자 이상의 비밀번호를 입력해 주세요."
                 />
-                <WarnMsg className={pwIsValid === false ? "" : "hidden"}>
+                <WarnMsg 
+                    className={pwIsValid === false ? "" : "hidden"}
+                    ref={warnPwRef}
+                >
                     비밀번호는 8자 이상이어야 합니다.
                 </WarnMsg>
             </UserInput>

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -50,7 +50,7 @@ export default function Form({ type }) {
             <Button
                 className="form-item"
                 type="submit"
-                data-testid="signup-button"
+                data-testid={`${type}-button`}
                 disabled={!isFormValid}
             >
                 { type === "signup" ? "회원가입" : "로그인" }

--- a/src/components/common/Form/Form.jsx
+++ b/src/components/common/Form/Form.jsx
@@ -1,10 +1,10 @@
-import FormCont from "../../common/FormCont/FormCont";
-import UserInput from "../../common/UserInput/UserInput";
-import WarnMsg from "../../common/WarnMsg/WarnMsg";
-import Button from "../../common/Button/Button";
+import FormCont from "../FormCont/FormCont";
+import UserInput from "../UserInput/UserInput";
+import WarnMsg from "../WarnMsg/WarnMsg";
+import Button from "../Button/Button";
 import useValidityCheck from "../../../hooks/useValidityCheck";
 
-export default function SignUpForm() {
+export default function Form({ type }) {
     const {
         emailValue,
         emailIsValid,
@@ -14,10 +14,10 @@ export default function SignUpForm() {
         isFormValid,
         emailChangeHandler,
         pwChangeHandler,
-        submitHandler
+        submitHandler,
     } = useValidityCheck();
     return (
-        <FormCont onSubmit={(e) => submitHandler(e, "signup")}>
+        <FormCont onSubmit={(e) => submitHandler(e, type)}>
             <UserInput label="이메일" inputId="email">
                 <input
                     id="email"
@@ -27,7 +27,12 @@ export default function SignUpForm() {
                     data-testid="email-input"
                     placeholder="이메일 주소를 입력해 주세요."
                 />
-                <WarnMsg className={emailIsValid === false ? "" : "hidden"} ref={warnEmailRef}>이메일은 "@"을 포함해야 합니다.</WarnMsg>
+                <WarnMsg
+                    className={emailIsValid === false ? "" : "hidden"}
+                    ref={warnEmailRef}
+                >
+                    이메일은 "@"을 포함해야 합니다.
+                </WarnMsg>
             </UserInput>
             <UserInput label="비밀번호" inputId="pw">
                 <input
@@ -38,7 +43,9 @@ export default function SignUpForm() {
                     data-testid="password-input"
                     placeholder="8자 이상의 비밀번호를 입력해 주세요."
                 />
-                <WarnMsg className={pwIsValid === false ? "" : "hidden"}>비밀번호는 8자 이상이어야 합니다.</WarnMsg>
+                <WarnMsg className={pwIsValid === false ? "" : "hidden"}>
+                    비밀번호는 8자 이상이어야 합니다.
+                </WarnMsg>
             </UserInput>
             <Button
                 className="form-item"
@@ -46,7 +53,7 @@ export default function SignUpForm() {
                 data-testid="signup-button"
                 disabled={!isFormValid}
             >
-                회원가입
+                { type === "signup" ? "회원가입" : "로그인" }
             </Button>
         </FormCont>
     );

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -3,7 +3,7 @@ import { createContext } from "react";
 const AuthContext = createContext({
     isLoggedIn: false,
     onLogout: () => {},
-    onLogin: () => {}
+    onLogin: (value) => {}
 });
 
 export default AuthContext;

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useReducer, useCallback, useRef } from "react";
+import { useState, useEffect, useReducer, useCallback, useRef, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import useHttp from "./use-http";
+import AuthContext from "../context/AuthContext";
 
 const emailReducer = (state, action) => {
     return action.type === "notUnique" ? 
@@ -32,6 +33,7 @@ export default function useValidityCheck() {
 
     const sendRequest = useHttp();
     const navigate = useNavigate();
+    const ctx = useContext(AuthContext);
 
     useEffect(() => {
         const identifier = setTimeout(() => {
@@ -75,6 +77,12 @@ export default function useValidityCheck() {
             responseHandler = (res) => {
                 res.status === 201 && navigate("/signin");
             };
+        } else {
+            responseHandler = (res) => {
+                if (res.status === 200) {
+                    ctx.onLogin(res.data.access_token);
+                }
+            };
         }
 
         let errorHandler;
@@ -87,7 +95,7 @@ export default function useValidityCheck() {
         }
 
         sendRequest(reqConfig, responseHandler, errorHandler);
-    }, [emailValue, pwValue, sendRequest, navigate]);
+    }, [emailValue, pwValue, sendRequest, navigate, ctx]);
 
     return {
         emailValue,

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -57,6 +57,7 @@ export default function useValidityCheck() {
 
     const submitHandler = useCallback((e, type) => {
         e.preventDefault();
+        console.log(type);
         const reqConfig = {
             method: "POST",
             URL: type === "signup" ? "/auth/signup" : "/auth/signin",

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -79,32 +79,31 @@ export default function useValidityCheck() {
             }
         };
 
-        let responseHandler;
-        if (type === "signup") {
-            responseHandler = (res) => {
-                res.status === 201 && navigate("/signin");
-            };
-        } else {
-            responseHandler = (res) => {
-                if (res.status === 200) {
-                    ctx.onLogin(res.data.access_token);
-                }
-            };
-        }
+        const handleSignupResponse = (res) => {
+            if (res.status === 201) {
+                navigate("/signin");
+            }
+        };
 
-        let errorHandler;
-        if (type === "signup") {
-            errorHandler = (err) => {
-                const errMsg = err.response.data.message;
-                warnEmailRef.current.textContent = errMsg;
-                dispatchEmail({ type: "notUnique" });
-            };
-        } else {
-            errorHandler = () => {
-                warnPwRef.current.textContent = "이메일 또는 비밀번호가 일치하지 않습니다.";
-                dispatchPw({ type: "loginDenied" });
-            };
-        }
+        const handleLoginResponse = (res) => {
+            if (res.status === 200) {
+                ctx.onLogin(res.data.access_token);
+            }
+        };
+
+        const handleSignupError = (err) => {
+            const errMsg = err.response.data.message || "Something went wrong";
+            warnEmailRef.current.textContent = errMsg;
+            dispatchEmail({ type: "notUnique" });
+        };
+
+        const handleLoginError = () => {
+            warnPwRef.current.textContent = "이메일 또는 비밀번호가 일치하지 않습니다.";
+            dispatchPw({ type: "loginDenied" });
+        };
+
+        const responseHandler = type === "signup" ? handleSignupResponse : handleLoginResponse;
+        const errorHandler = type === "signup" ? handleSignupError : handleLoginError;
 
         sendRequest(reqConfig, responseHandler, errorHandler);
     }, [emailValue, pwValue, sendRequest, navigate, ctx]);

--- a/src/hooks/useValidityCheck.jsx
+++ b/src/hooks/useValidityCheck.jsx
@@ -10,7 +10,9 @@ const emailReducer = (state, action) => {
 };
 
 const passwordReducer = (state, action) => {
-    return { value: action.val, isValid: action.val.length >= 8 };
+    return action.type === "loginDenied" ? 
+        { value: state.value, isValid: false } :
+        { value: action.val, isValid: action.val.length >= 8 };
 };
 
 export default function useValidityCheck() {
@@ -30,6 +32,7 @@ export default function useValidityCheck() {
     const { value: pwValue, isValid: pwIsValid } = pwState;
 
     const warnEmailRef = useRef();
+    const warnPwRef = useRef();
 
     const sendRequest = useHttp();
     const navigate = useNavigate();
@@ -54,6 +57,10 @@ export default function useValidityCheck() {
     }, []);
 
     const pwChangeHandler = useCallback((e) => {
+        if (warnPwRef.current.textContent !== "비밀번호는 8자 이상이어야 합니다.") {
+            console.log("경고 메시지 다시 초기값으로");
+            warnPwRef.current.textContent = "비밀번호는 8자 이상이어야 합니다.";
+        }
         dispatchPw({ val: e.target.value });
     }, []);
 
@@ -92,6 +99,11 @@ export default function useValidityCheck() {
                 warnEmailRef.current.textContent = errMsg;
                 dispatchEmail({ type: "notUnique" });
             };
+        } else {
+            errorHandler = () => {
+                warnPwRef.current.textContent = "이메일 또는 비밀번호가 일치하지 않습니다.";
+                dispatchPw({ type: "loginDenied" });
+            };
         }
 
         sendRequest(reqConfig, responseHandler, errorHandler);
@@ -103,6 +115,7 @@ export default function useValidityCheck() {
         warnEmailRef,
         pwValue,
         pwIsValid,
+        warnPwRef,
         isFormValid,
         emailChangeHandler,
         pwChangeHandler,

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -1,5 +1,11 @@
-import React from "react";
+import LabelOnTop from "../components/common/LabelOnTop/LabelOnTop";
+import Form from "../components/common/Form/Form";
 
 export default function SignIn() {
-    return <div>SignIn</div>;
+    return (
+        <>
+            <LabelOnTop>로그인</LabelOnTop>
+            <Form type="signin" />
+        </>
+    );
 }

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,11 +1,11 @@
 import LabelOnTop from "../components/common/LabelOnTop/LabelOnTop";
-import SignUpForm from "../components/signup/SignUpForm/SignUpForm";
+import Form from "../components/common/Form/Form";
 
 export default function SignUp() {
     return (
         <>
             <LabelOnTop>회원가입</LabelOnTop>
-            <SignUpForm />
+            <Form type="signup" />
         </>
     );
 }


### PR DESCRIPTION
# [Refactor: signup 페이지 전용 컴포넌트 SignUpForm을 공용 컴포넌트 Form으로](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/18/commits/d553fe67c2328d809f36a0cf96902c0e11032a83)
* 수정 전: components/signin/SignUpForm/SignUpForm.jsx는 회원가입 페이지 전용 컴포넌트 였음
* 그런데 로그인, 회원가입 모두 버튼 빼고 UI가 같아서 컴포넌트를 재활용하는 것이 좋다고 생각
* 수정 후: components/common/Form.jsx로 공통 컴포넌트로 지정, 페이지 컴포넌트에서 Form 컴포넌트 사용시 props로 회원가입인지 로그인지 type을 알려주는 형식으로

# [Markup: 로그인 페이지](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/18/commits/2c37c360366779dd45241876aebb84e050fc556a)
* 페이지 타입에 따라 버튼의 data-testid가 달라지도록 템플릿 리터럴 활용

# [Feat: 로그인 요청 후 성공시 로컬 스토리지 저장 및 /todo 경로로 이동](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/18/commits/2738e7ab708fe3663b1101ab70447eb81c69aa7e)
*  useValidityCheck.jsx
    * Auth Context의 onLogin 활용
* AuthContext.jsx
    * 자동 완성 위해 onLogin: (value) => {} 형태로

# [Feat: 로그인 요청 실패시 버튼 비활성화 및 경고 메시지 보이기](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/18/commits/3af9401e0b727d1cf48582765a8438519740c241)
* 이메일 중복 체크와 같은 논리로, 비밀번호 인풋 하단 경고 메시지 컴포넌트에 useRef를 걸었음
* 추후 useRef 사용 안 하고 useState를 사용할 수 있을지 한 번 고민해봐야 할듯

# [Refactor: useValidityCheck.jsx의 responseHandler와 errorHandler 부분 가독성 좋게](https://github.com/SEMINSEMINSEMIN/wanted-pre-onboarding-frontend/pull/18/commits/aff0953bccc0a661f2e51e1c08faeb9439beb921)